### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ tensorboard==2.5.0
 ray==1.8.0
 opencv-python==4.5.2.52
 pygifsicle==1.0.4
-gym==0.21.0
+gym[classic_control]==0.21.0
 mlagents-envs==0.26.0
 procgen==0.10.4


### PR DESCRIPTION
Install gym package with "classic_control" parameter for supporting the render option

:star2: Hello! Thanks for contributing JORLDY! 

### Checklist 

Please check if you consider the following items. 

- [v] My code follows the style guidelines of this project
- [v] My code follows the [naming convention](https://github.com/kakaoenterprise/JORLDY/blob/master/docs/Naming_convention.md) of documentation
- [v] I have commented my code, particularly in hard-to-understand areas
- [v] My changes generate no new warnings or errors 



### Types of changes 
Suggestion, requirements.txt



### Test Configuration

- OS: Ubuntu 18.04.05 LTS
- Python version: 3.6.9
- Additional libraries: None



### Description
After clean install JORLDY.
I make the render option "True" in gym environments. then, I can see an error message like "Can not import pyglet".

How about that adding a "classic_control" square bracket option for a beginner who wants to see the rendered cart_pole or mountain_car scene?

Also, This option helps to follow the proper pyglet package version with the gym.