### PR TITLE
Modify train files, eval_manager

### DIFF
--- a/jorldy/async_distributed_train.py
+++ b/jorldy/async_distributed_train.py
@@ -22,6 +22,8 @@ if __name__ == "__main__":
                     'action_size': env.action_size,
                     'optim_config': config.optim,
                     'num_workers': config.train.num_workers}
+    env.close()
+    
     agent_config.update(config.agent)
     if config.train.distributed_batch_size:
         agent_config["batch_size"] = config.train.distributed_batch_size
@@ -33,7 +35,7 @@ if __name__ == "__main__":
     path_queue = mp.Queue(1)
     
     record_period = config.train.record_period if config.train.record_period else config.train.run_step//10
-    eval_manager_config = (Env(**config.env), config.train.eval_iteration, config.train.record, record_period)
+    eval_manager_config = (Env, config.env, config.train.eval_iteration, config.train.record, record_period)
     log_id = config.train.id if config.train.id else config.agent.name
     log_manager_config = (config.env.name, log_id, config.train.experiment)
     manage = mp.Process(target=manage_process,

--- a/jorldy/manager/eval_manager.py
+++ b/jorldy/manager/eval_manager.py
@@ -5,7 +5,7 @@ class EvalManager:
         self.env = Env(**env_config)
         self.iteration = iteration if iteration else 10
         assert iteration > 0
-        self.record = record and env.recordable()
+        self.record = record and self.env.recordable()
         self.record_period = record_period
         self.record_stamp = 0
         self.time_t = 0

--- a/jorldy/manager/eval_manager.py
+++ b/jorldy/manager/eval_manager.py
@@ -1,8 +1,8 @@
 import numpy as np 
 
 class EvalManager:
-    def __init__(self, env, iteration=10, record=None, record_period=None):
-        self.env = env
+    def __init__(self, Env, env_config, iteration=10, record=None, record_period=None):
+        self.env = Env(**env_config)
         self.iteration = iteration if iteration else 10
         assert iteration > 0
         self.record = record and env.recordable()

--- a/jorldy/single_train.py
+++ b/jorldy/single_train.py
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     path_queue = mp.Queue(1)
     
     record_period = config.train.record_period if config.train.record_period else config.train.run_step//10
-    eval_manager_config = (Env(**config.env), config.train.eval_iteration, config.train.record, record_period)
+    eval_manager_config = (Env, config.env, config.train.eval_iteration, config.train.record, record_period)
     log_id = config.train.id if config.train.id else config.agent.name
     log_manager_config = (config.env.name, log_id, config.train.experiment)
     manage = mp.Process(target=manage_process,

--- a/jorldy/sync_distributed_train.py
+++ b/jorldy/sync_distributed_train.py
@@ -22,6 +22,8 @@ if __name__ == "__main__":
                     'action_size': env.action_size,
                     'optim_config': config.optim,
                     'num_workers': config.train.num_workers}
+    env.close()
+    
     agent_config.update(config.agent)
     if config.train.distributed_batch_size:
         agent_config["batch_size"] = config.train.distributed_batch_size
@@ -31,7 +33,7 @@ if __name__ == "__main__":
     path_queue = mp.Queue(1)
     
     record_period = config.train.record_period if config.train.record_period else config.train.run_step//10
-    eval_manager_config = (Env(**config.env), config.train.eval_iteration, config.train.record, record_period)
+    eval_manager_config = (Env, config.env, config.train.eval_iteration, config.train.record, record_period)
     log_id = config.train.id if config.train.id else config.agent.name
     log_manager_config = (config.env.name, log_id, config.train.experiment)
     manage = mp.Process(target=manage_process,


### PR DESCRIPTION
:star2: Hello! Thanks for contributing JORLDY! 

### Checklist 

Please check if you consider the following items. 

- [v] My code follows the style guidelines of this project
- [v] My code follows the [naming convention](https://github.com/kakaoenterprise/JORLDY/blob/master/docs/Naming_convention.md) of documentation
- [v] I have commented my code, particularly in hard-to-understand areas
- [v] My changes generate no new warnings or errors 



### Types of changes 
Bugfix


### Test Configuration

- OS: Windows 10
- Python version: 3.8
- Additional libraries: None



### Description

- Fixed #44 

The basic idea is that eval_manager in the child process should create its env.
For now, distributed_train.py process doesn’t use env after creating agent config.