### PR TITLE
[#130]Debug/fix step calculation in async_distributed_train

### DIFF
--- a/jorldy/core/agent/ape_x.py
+++ b/jorldy/core/agent/ape_x.py
@@ -154,12 +154,12 @@ class ApeX(DQN):
         ):
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_period_stamp = 0
+            self.learn_period_stamp -= self.learn_period
 
         # Process per step if train start
         if self.num_learn > 0 and self.target_update_stamp >= self.target_update_period:
             self.update_target()
-            self.target_update_stamp = 0
+            self.target_update_stamp = self.target_update_period
 
         return result
 

--- a/jorldy/core/agent/dqn.py
+++ b/jorldy/core/agent/dqn.py
@@ -169,7 +169,7 @@ class DQN(BaseAgent):
 
             if self.target_update_stamp >= self.target_update_period:
                 self.update_target()
-                self.target_update_stamp = 0
+                self.target_update_stamp -= self.target_update_period
 
         return result
 

--- a/jorldy/core/agent/multistep.py
+++ b/jorldy/core/agent/multistep.py
@@ -82,7 +82,7 @@ class Multistep(DQN):
 
             if self.target_update_stamp >= self.target_update_period:
                 self.update_target()
-                self.target_update_stamp = 0
+                self.target_update_stamp -= self.target_update_period
 
         return result
 

--- a/jorldy/core/agent/noisy.py
+++ b/jorldy/core/agent/noisy.py
@@ -138,6 +138,6 @@ class Noisy(DQN):
         if self.num_learn > 0:
             if self.target_update_stamp >= self.target_update_period:
                 self.update_target()
-                self.target_update_stamp = 0
+                self.target_update_stamp -= self.target_update_period
 
         return result

--- a/jorldy/core/agent/per.py
+++ b/jorldy/core/agent/per.py
@@ -108,7 +108,7 @@ class PER(DQN):
         ):
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_period_stamp = 0
+            self.learn_period_stamp -= self.learn_period
 
         # Process per step if train start
         if self.num_learn > 0:
@@ -116,6 +116,6 @@ class PER(DQN):
 
             if self.target_update_stamp >= self.target_update_period:
                 self.update_target()
-                self.target_update_stamp = 0
+                self.target_update_stamp -= self.target_update_period
 
         return result

--- a/jorldy/core/agent/ppo.py
+++ b/jorldy/core/agent/ppo.py
@@ -196,6 +196,6 @@ class PPO(REINFORCE):
         if self.learn_stamp >= self.n_step:
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_stamp = 0
+            self.learn_stamp -= self.n_step
 
         return result

--- a/jorldy/core/agent/r2d2.py
+++ b/jorldy/core/agent/r2d2.py
@@ -268,7 +268,7 @@ class R2D2(ApeX):
             del _transition["q"]
 
             self.store_start = False
-            self.store_period_stamp = 0
+            self.store_period_stamp -= self.store_period
 
         if (
             len(self.tmp_buffer) > self.n_step

--- a/jorldy/core/agent/rainbow.py
+++ b/jorldy/core/agent/rainbow.py
@@ -270,12 +270,12 @@ class Rainbow(DQN):
         ):
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_period_stamp = 0
+            self.learn_period_stamp -= self.learn_period
 
         # Process per step if train start
         if self.num_learn > 0 and self.target_update_stamp >= self.target_update_period:
             self.update_target()
-            self.target_update_stamp = 0
+            self.target_update_stamp -= self.target_update_period
 
         return result
 

--- a/jorldy/core/agent/rnd_ppo.py
+++ b/jorldy/core/agent/rnd_ppo.py
@@ -275,7 +275,7 @@ class RND_PPO(PPO):
         if self.learn_stamp >= self.n_step:
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_stamp = 0
+            self.learn_stamp -= self.n_step
 
         return result
 

--- a/jorldy/core/agent/vmpo.py
+++ b/jorldy/core/agent/vmpo.py
@@ -285,6 +285,6 @@ class VMPO(REINFORCE):
         if self.learn_stamp >= self.n_step:
             result = self.learn()
             self.learning_rate_decay(step)
-            self.learn_stamp = 0
+            self.learn_stamp -= self.n_step
 
         return result

--- a/jorldy/manager/eval_manager.py
+++ b/jorldy/manager/eval_manager.py
@@ -58,5 +58,5 @@ class EvalManager:
             scores.append(self.env.score)
 
         if record:
-            self.record_stamp = 0
+            self.record_stamp -= self.record_period
         return round(np.mean(scores), 4), frames

--- a/jorldy/run_mode.py
+++ b/jorldy/run_mode.py
@@ -375,7 +375,7 @@ def evaluate(config_path, unknown):
     assert config.train.load_path
     agent.load(config.train.load_path)
 
-    episode, score = 0, 0
+    episode = 0
     state = env.reset()
     for step in range(1, config.train.run_step + 1):
         action_dict = agent.act(state, training=False)
@@ -393,6 +393,5 @@ def evaluate(config_path, unknown):
             episode += 1
             print(f"{episode} Episode / Step : {step} / Score: {env.score}")
             state = env.reset()
-            score = 0
 
     env.close()

--- a/jorldy/run_mode.py
+++ b/jorldy/run_mode.py
@@ -317,10 +317,10 @@ def async_distributed_train(config_path, unknown):
             is_over = step >= heap["run_step"]
             if heap["print_stamp"] >= config.train.print_period or is_over:
                 print_signal = True
-                heap["print_stamp"] = 0
+                heap["print_stamp"] -= config.train.print_period
             if heap["save_stamp"] >= config.train.save_period or is_over:
                 save_signal = True
-                heap["save_stamp"] = 0
+                heap["save_stamp"] -= config.train.save_period
             heap["wait_thread"] = False
             result = agent.process(_transitions, step)
             try:

--- a/jorldy/run_mode.py
+++ b/jorldy/run_mode.py
@@ -191,10 +191,10 @@ def sync_distributed_train(config_path, unknown):
                 except:
                     pass
                 manage_sync_queue.put(agent.sync_out())
-                print_stamp = 0
+                print_stamp -= config.train.print_period
             if save_stamp >= config.train.save_period or is_over:
                 agent.save(save_path)
-                save_stamp = 0
+                save_stamp -= config.train.save_period
     except Exception as e:
         traceback.print_exc()
         manage.terminate()


### PR DESCRIPTION
:star2: Hello! Thanks for contributing JORLDY! 

### Checklist 

Please check if you consider the following items. 

- [x] My code follows the style guidelines of this project [contributing](https://github.com/kakaoenterprise/JORLDY/blob/master/CONTRIBUTING.md)
- [x] My code follows the [naming convention](https://github.com/kakaoenterprise/JORLDY/blob/master/docs/Naming_convention.md) of documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors 



### Types of changes 

**Please describe the types of changes! (ex. Bugfix, New feature, Documentation, ...)**
Bugfix


### Test Configuration

- OS: mac
- Python version: 3.8.12
- Additional libraries: vscode-conda



### Description

**Please describe the details of your contribution**

In each asynchronous loop, a different number of steps comes in each time, and now it is reset to "heap["print_stamp"] = 0 " as in the following code.

```python
if heap["print_stamp"] >= config.train.print_period or is_over:
    print_signal = True
    heap["print_stamp"] = 0 # 50100.25->0, loss 100.25 step

...

if print_signal: # 49899.75 >= 50000 at last loop
    try:
        manage_sync_queue.get_nowait()
    except:
        pass
    manage_sync_queue.put(agent.sync_out()) # no execution in the last loop.
```
In fact, if it is updated at heap["print_stamp"]=50100 of 50000 period, it should be updated after an additional 49900 steps.
Currently, while updating heap["print_stamp"]=0, the entire step is finished after the last additional 49900 steps, but a is not updated and the loop does not end.

So, fix it like this:
```python
if heap["print_stamp"] >= config.train.print_period or is_over:
    print_signal = True
    heap["print_stamp"] -= config.train.print_period # fix
```