### PR TITLE
modify get_stacked_data method

### DIFF
--- a/jorldy/core/agent/muzero.py
+++ b/jorldy/core/agent/muzero.py
@@ -565,16 +565,17 @@ class Trajectory(dict):
         return value
 
     def get_stacked_data(self, cur_idx, num_stack):
-        shape = self["states"][cur_idx].shape[-2:]
-        actions = np.zeros((num_stack, *shape))
-        states = np.zeros((num_stack + 1, *shape))
-        states[0] = self["states"][cur_idx]
+        channel, *plane = self["states"][cur_idx].shape[1:]
+        actions = np.zeros((num_stack, *plane))
+        states = np.zeros(((num_stack + 1) * channel, *plane))
 
         for i, state in enumerate(
             self["states"][max(0, cur_idx - num_stack) : cur_idx]
         ):
-            states[i + 1] = state
-            actions[i] = np.ones(shape) * self["actions"][i]
+            j = i * channel
+            states[j : j + channel] = state
+            actions[i] = np.ones(plane) * self["actions"][i]
+        states[-channel:] = self["states"][cur_idx]
 
         return states, actions
 


### PR DESCRIPTION
:star2: Hello! Thanks for contributing JORLDY! 

### Checklist 

Please check if you consider the following items. 

- [x] My code follows the style guidelines of this project [contributing](https://github.com/kakaoenterprise/JORLDY/blob/master/CONTRIBUTING.md)
- [x] My code follows the [naming convention](https://github.com/kakaoenterprise/JORLDY/blob/master/docs/Naming_convention.md) of documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors 



### Types of changes 

**Please describe the types of changes! (ex. Bugfix, New feature, Documentation, ...)**



### Test Configuration

- OS: mac
- Python version: 3.8.11
- Additional libraries: vscode atari



### Description
Modify get_stacked_data method to enable Atari multi-channel (rgb) processing
