### PR TITLE
[#157] init actors netwrok and modify rollout buffer stamp

### DIFF
--- a/jorldy/config/ppo/mujoco.py
+++ b/jorldy/config/ppo/mujoco.py
@@ -9,9 +9,9 @@ agent = {
     "name": "ppo",
     "network": "continuous_policy_value",
     "gamma": 0.99,
-    "batch_size": 32,
-    "n_step": 128,
-    "n_epoch": 3,
+    "batch_size": 512,
+    "n_step": 2048,
+    "n_epoch": 10,
     "_lambda": 0.95,
     "epsilon_clip": 0.1,
     "vf_coef": 1.0,
@@ -22,20 +22,20 @@ agent = {
 
 optim = {
     "name": "adam",
-    "lr": 2.5e-4,
+    "lr": 3e-4,
 }
 
 train = {
     "training": True,
     "load_path": None,
-    "run_step": 30000000,
+    "run_step": 1000000,
     "print_period": 10000,
     "save_period": 100000,
-    "eval_iteration": 5,
+    "eval_iteration": 10,
     "record": True,
-    "record_period": 300000,
+    "record_period": 500000,
     # distributed setting
-    "distributed_batch_size": 256,
+    "distributed_batch_size": 2048,
     "update_period": agent["n_step"],
     "num_workers": 8,
 }

--- a/jorldy/core/agent/mpo.py
+++ b/jorldy/core/agent/mpo.py
@@ -449,7 +449,6 @@ class MPO(BaseAgent):
 
         # Process per step
         self.memory.store(transitions)
-        delta_t = step - self.time_t
         self.time_t = step
 
         if self.memory.size >= self.batch_size and self.time_t >= self.start_train_step:

--- a/jorldy/core/agent/ppo.py
+++ b/jorldy/core/agent/ppo.py
@@ -197,6 +197,6 @@ class PPO(REINFORCE):
             result = self.learn()
             if self.lr_decay:
                 self.learning_rate_decay(step)
-            self.learn_stamp -= self.n_step
+            self.learn_stamp = 0
 
         return result

--- a/jorldy/core/agent/rainbow.py
+++ b/jorldy/core/agent/rainbow.py
@@ -28,7 +28,6 @@ class Rainbow(DQN):
         start_train_step (int): steps to start learning.
         target_update_period (int): period to update the target network. (unit: step)
         run_step (int): the number of total steps.
-        lr_decay: lr_decay option which apply decayed weight on parameters of network.
         n_step: number of steps in multi-step Q learning.
         alpha (float): prioritization exponent.
         beta (float): initial value of degree to use importance sampling.
@@ -57,7 +56,6 @@ class Rainbow(DQN):
         start_train_step=2000,
         target_update_period=500,
         run_step=1e6,
-        lr_decay=True,
         # MultiStep
         n_step=4,
         # PER
@@ -108,7 +106,6 @@ class Rainbow(DQN):
         self.num_learn = 0
         self.time_t = 0
         self.run_step = run_step
-        self.lr_decay = lr_decay
 
         # MultiStep
         self.n_step = n_step
@@ -271,9 +268,8 @@ class Rainbow(DQN):
             and self.time_t >= self.start_train_step
         ):
             result = self.learn()
-            if self.lr_decay:
-                self.learning_rate_decay(step)
-            self.learn_period_stamp = 0
+            self.learning_rate_decay(step)
+            self.learn_period_stamp -= self.learn_period
 
         # Process per step if train start
         if self.num_learn > 0 and self.target_update_stamp >= self.target_update_period:

--- a/jorldy/core/agent/rainbow.py
+++ b/jorldy/core/agent/rainbow.py
@@ -273,7 +273,7 @@ class Rainbow(DQN):
             result = self.learn()
             if self.lr_decay:
                 self.learning_rate_decay(step)
-            self.learn_period_stamp -= self.learn_period
+            self.learn_period_stamp = 0
 
         # Process per step if train start
         if self.num_learn > 0 and self.target_update_stamp >= self.target_update_period:

--- a/jorldy/core/agent/rainbow.py
+++ b/jorldy/core/agent/rainbow.py
@@ -28,6 +28,7 @@ class Rainbow(DQN):
         start_train_step (int): steps to start learning.
         target_update_period (int): period to update the target network. (unit: step)
         run_step (int): the number of total steps.
+        lr_decay: lr_decay option which apply decayed weight on parameters of network.
         n_step: number of steps in multi-step Q learning.
         alpha (float): prioritization exponent.
         beta (float): initial value of degree to use importance sampling.
@@ -56,6 +57,7 @@ class Rainbow(DQN):
         start_train_step=2000,
         target_update_period=500,
         run_step=1e6,
+        lr_decay=True,
         # MultiStep
         n_step=4,
         # PER
@@ -106,6 +108,7 @@ class Rainbow(DQN):
         self.num_learn = 0
         self.time_t = 0
         self.run_step = run_step
+        self.lr_decay = lr_decay
 
         # MultiStep
         self.n_step = n_step
@@ -268,7 +271,8 @@ class Rainbow(DQN):
             and self.time_t >= self.start_train_step
         ):
             result = self.learn()
-            self.learning_rate_decay(step)
+            if self.lr_decay:
+                self.learning_rate_decay(step)
             self.learn_period_stamp -= self.learn_period
 
         # Process per step if train start

--- a/jorldy/core/agent/vmpo.py
+++ b/jorldy/core/agent/vmpo.py
@@ -286,6 +286,6 @@ class VMPO(REINFORCE):
             result = self.learn()
             if self.lr_decay:
                 self.learning_rate_decay(step)
-            self.learn_stamp -= self.n_step
+            self.learn_stamp = 0
 
         return result

--- a/jorldy/manager/distributed_manager.py
+++ b/jorldy/manager/distributed_manager.py
@@ -52,8 +52,8 @@ class DistributedManager:
 
         return transitions, completed_ratio
 
-    def sync(self, sync_item):
-        if self.mode == "sync":
+    def sync(self, sync_item, init=False):
+        if self.mode == "sync" or init:
             sync_item = ray.put(sync_item)
             ray.get([actor.sync.remote(sync_item) for actor in self.actors])
         else:

--- a/jorldy/process.py
+++ b/jorldy/process.py
@@ -12,6 +12,7 @@ def interact_process(
     update_period,
 ):
     distributed_manager = DistributedManager(*distributed_manager_config)
+    distributed_manager.sync(sync_queue.get(), init=True)
     step = 0
     try:
         while step < run_step:

--- a/jorldy/run_mode.py
+++ b/jorldy/run_mode.py
@@ -173,6 +173,7 @@ def sync_distributed_train(config_path, unknown):
         assert agent.action_type == env.action_type
         if config.train.load_path:
             agent.load(config.train.load_path)
+        distributed_manager.sync(agent.sync_out())
 
         save_path = path_queue.get()
         step, print_stamp, save_stamp = 0, 0, 0
@@ -290,6 +291,7 @@ def async_distributed_train(config_path, unknown):
         assert agent.action_type == env.action_type
         if config.train.load_path:
             agent.load(config.train.load_path)
+        interact_sync_queue.put(agent.sync_out())
 
         save_path = path_queue.get()
         heap = {


### PR DESCRIPTION
:star2: Hello! Thanks for contributing JORLDY! 

### Checklist 

Please check if you consider the following items. 

- [x] My code follows the style guidelines of this project [contributing](https://github.com/kakaoenterprise/JORLDY/blob/master/CONTRIBUTING.md)
- [x] My code follows the [naming convention](https://github.com/kakaoenterprise/JORLDY/blob/master/docs/Naming_convention.md) of documentation
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors 



### Types of changes 
feature


### Test Configuration

- OS: linux, mac
- Python version: 3.7.11
- Additional libraries: V4XLARGE, jorldy:0.3.0



### Description
1. In sync and async, the Actor's network is initialized to a different value than the learner's network, and then the problem is solved.
2. When using the rollout buffer, the stamp in process is set to 0.



